### PR TITLE
Rename app to Germinauta and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024 Germinauta
+
+All rights reserved.
+
+This repository is publicly accessible for viewing and discussion. Any use, copying, modification, merging, publishing, distribution, sublicensing, or selling of the code or content is prohibited without explicit written permission from the copyright holder.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Habit Reinforcer</title>
+  <title>Germinauta</title>
   <link rel="manifest" href="manifest.json" />
   <link rel="stylesheet" href="style.css" />
   <meta name="theme-color" content="#dff4ff" />

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Habit Reinforcer",
-  "short_name": "HabitApp",
+  "name": "Germinauta",
+  "short_name": "Germinauta",
   "start_url": "index.html",
   "display": "standalone",
   "background_color": "#dff4ff",


### PR DESCRIPTION
## Summary
- rename PWA from Habit Reinforcer to Germinauta
- add protective license file

## Testing
- `node --check app.js`
- `node --check service-worker.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689abff52b64832e83fb2378bdae1e34