### PR TITLE
feat: play completion sound after actions

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,7 @@ const statMonth = document.getElementById("stat-month");
 const statTotal = document.getElementById("stat-total");
 const sfxTap = document.getElementById("sfx-tap");
 const sfxStage = document.getElementById("sfx-stage");
+const sfxComplete = document.getElementById("sfx-complete");
 const btnSettings = document.getElementById("btn-settings");
 const settingsSheet = document.getElementById("settings");
 const addButton = document.getElementById("add-button");
@@ -66,6 +67,8 @@ function handleAction(label) {
     playTapSound();
   }
 
+  playCompleteSound();
+
   updateStats();
 }
 
@@ -92,6 +95,9 @@ function playTapSound() {
 }
 function playStageSound() {
   safePlay(sfxStage);
+}
+function playCompleteSound() {
+  safePlay(sfxComplete);
 }
 function safePlay(audioEl) {
   try {

--- a/index.html
+++ b/index.html
@@ -19,8 +19,9 @@
       <div id="environment"></div>
       <img id="creature" alt="Criatura" src="assets/images/stage1.png" />
       <div id="buttons"></div>
-      <audio id="sfx-tap" src="assets/sounds/tap.mp3" preload="auto"></audio>
-      <audio id="sfx-stage" src="assets/sounds/stage-change.mp3" preload="auto"></audio>
+      <audio id="sfx-tap" src="assets/tap.wav" preload="auto"></audio>
+      <audio id="sfx-stage" src="assets/stage-change.wav" preload="auto"></audio>
+      <audio id="sfx-complete" src="assets/action-complete.wav" preload="auto"></audio>
     </main>
 
     <section id="stats" hidden>

--- a/service-worker.js
+++ b/service-worker.js
@@ -13,8 +13,9 @@ const ASSETS = [
   "./assets/images/stage4.png",
   "./assets/images/stage5.png",
   "./assets/images/stage6.png",
-  "./assets/sounds/tap.mp3",
-  "./assets/sounds/stage-change.mp3"
+  "./assets/tap.wav",
+  "./assets/stage-change.wav",
+  "./assets/action-complete.wav"
 ];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
- reference the new `action-complete.wav` asset in the scene
- play completion sound after each action and cache audio assets in the service worker
- align existing sound references to `.wav`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689abb33dc38832ea2a6b76ca0e3c5ed