### PR TITLE
Add Apple mobile web app meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Habit Reinforcer</title>
   <link rel="manifest" href="manifest.json" />
+  <link rel="apple-touch-icon" href="assets/icon-192.png" />
   <link rel="stylesheet" href="style.css" />
   <meta name="theme-color" content="#dff4ff" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
 </head>
 <body>
   <div id="app">


### PR DESCRIPTION
## Summary
- link Apple touch icon using correct asset path
- enable standalone iOS display and status bar style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689abf63c428832eb893b724082ad05b