### PR TITLE
Ensure manifest launches at app root

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,21 @@
 {
   "name": "Germinauta",
   "short_name": "Germinauta",
-  "start_url": "index.html",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#dff4ff",
   "theme_color": "#dff4ff",
   "icons": [
-    { "src": "assets/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "assets/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+    {
+      "src": "assets/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "assets/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Point `start_url` and `scope` in `manifest.json` to the application root

## Testing
- `npx prettier --check manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_689ac60b2c08832e966f1ba5716275e3