### PR TITLE
Fix apple-touch icon path

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Germinauta</title>
     <link rel="manifest" href="manifest.json" />
-    <link rel="apple-touch-icon" href="assets/icon-192.png" />
+    <link rel="apple-touch-icon" href="assets/icons/icon-192.png" />
     <link rel="stylesheet" href="style.css" />
     <meta name="theme-color" content="#dff4ff" />
     <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Summary
- Correct apple-touch icon path to use `assets/icons` directory
- Confirm service worker asset list covers all offline icons, images, and sounds

## Testing
- `npx prettier --check index.html`

------
https://chatgpt.com/codex/tasks/task_e_689ac7375a88832e95255c9ca4e6a70b