### PR TITLE
Revamp PWA layout and assets

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,13 +85,12 @@ function renderButtons() {
     btn.addEventListener("click", () => handleAction(b.label));
     buttonsEl.appendChild(btn);
   });
-  applyDownwardArc(buttonsEl);
+  applyBottomArc(buttonsEl);
 }
 
 function renderStage() {
   const s = settings.stage;
   creatureEl.src = `assets/images/stage${s}.png`;
-  envEl.style.backgroundImage = `url('assets/images/stage${s}.png')`;
 }
 
 function playTapSound() {
@@ -275,18 +274,15 @@ function move(arr, from, to) {
 }
 
 // Curva hacia abajo en el centro, dinámica
-function applyDownwardArc(container) {
+function applyBottomArc(container) {
   const items = Array.from(container.children);
   const n = items.length;
   if (n === 0) return;
-  const mid = (n - 1) / 2;
-  const amplitude = 10; // px extra hacia arriba en extremos
+  const radius = 40;
+  const step = Math.PI / (n - 1);
   items.forEach((el, i) => {
-    const offset =
-      -Math.pow(i - mid, 2) * (amplitude / (mid === 0 ? 1 : mid * mid)) +
-      amplitude;
-    // Queremos el centro más bajo. Desplazamos Y positiva hacia abajo.
-    const down = amplitude - offset; // centro más grande
-    el.style.transform = `translateY(${down.toFixed(1)}px)`;
+    const angle = step * i;
+    const y = Math.sin(angle) * radius;
+    el.style.setProperty("--arc-y", `${y.toFixed(1)}px`);
   });
 }

--- a/index.html
+++ b/index.html
@@ -22,15 +22,19 @@
         <div id="environment"></div>
         <img id="creature" alt="Criatura" src="assets/images/stage1.png" />
         <div id="buttons"></div>
-        <audio id="sfx-tap" src="assets/sounds/tap.wav" preload="auto"></audio>
+        <audio
+          id="sfx-tap"
+          src="./assets/sounds/tap.wav"
+          preload="auto"
+        ></audio>
         <audio
           id="sfx-stage"
-          src="assets/sounds/stage-change.wav"
+          src="./assets/sounds/stage-change.wav"
           preload="auto"
         ></audio>
         <audio
           id="sfx-complete"
-          src="assets/sounds/action-complete.wav"
+          src="./assets/sounds/action-complete.wav"
           preload="auto"
         ></audio>
       </main>

--- a/style.css
+++ b/style.css
@@ -21,8 +21,8 @@ body {
     Segoe UI,
     Roboto,
     sans-serif;
-  background: var(--bg);
-  color: #123;
+  background: #000000;
+  color: #fff;
 }
 
 #app {
@@ -32,10 +32,7 @@ body {
 }
 
 #hud {
-  display: flex;
-  gap: 8px;
-  padding: 8px;
-  justify-content: flex-end;
+  display: none;
 }
 
 #hud button {
@@ -55,18 +52,15 @@ body {
 }
 
 #environment {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(ellipse at 50% 75%, #eafaff 0%, #c8efff 80%);
-  z-index: 1;
+  display: none;
 }
 
 #creature {
   position: absolute;
   left: 50%;
-  top: 45%;
+  top: 50%;
   transform: translate(-50%, -50%);
-  width: min(70vw, 420px);
+  width: 100%;
   height: auto;
   z-index: 2;
   pointer-events: none;
@@ -82,14 +76,10 @@ body {
   align-items: flex-end;
   gap: 12px;
   z-index: 3;
-  padding: 6px 10px;
-  background: rgba(255, 255, 255, 0.7);
-  backdrop-filter: blur(6px);
-  border-radius: 18px;
-  box-shadow: var(--shadow);
 }
 
 #buttons .action {
+  --arc-y: 0px;
   width: 64px;
   height: 64px;
   border-radius: 50%;
@@ -98,12 +88,16 @@ body {
   color: #402;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.18);
-  transition: transform 0.08s ease;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+  transition:
+    transform 0.08s ease,
+    box-shadow 0.08s ease;
+  transform: translateY(var(--arc-y));
 }
 
 #buttons .action:active {
-  transform: scale(0.92);
+  transform: translateY(calc(var(--arc-y) + 2px)) scale(0.94);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
 }
 
 /* Paneles superpuestos */


### PR DESCRIPTION
## Summary
- use relative audio paths so sound effects play
- overhaul styling: black background, hide HUD, transparent button bar and curved buttons with shadows
- scale creature to full width and compute button arc in JS

## Testing
- `npx prettier --check index.html style.css app.js`

------
https://chatgpt.com/codex/tasks/task_e_689aca3259e8832e855517e909bb4b62