### PR TITLE
Fix missing UI controls and improve button feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,13 +41,11 @@
 
       <section id="stats" hidden>
         <div class="panel">
+          <button id="close-stats" class="close" aria-label="Cerrar">✕</button>
           <div><strong>Hoy:</strong> <span id="stat-today">0</span></div>
           <div><strong>Semana:</strong> <span id="stat-week">0</span></div>
           <div><strong>Mes:</strong> <span id="stat-month">0</span></div>
           <div><strong>Total:</strong> <span id="stat-total">0</span></div>
-          <div class="row end">
-            <button id="close-stats">Cerrar</button>
-          </div>
         </div>
       </section>
 

--- a/style.css
+++ b/style.css
@@ -32,7 +32,10 @@ body {
 }
 
 #hud {
-  display: none;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 8px;
 }
 
 #hud button {
@@ -43,6 +46,14 @@ body {
   border-radius: 10px;
   box-shadow: var(--shadow);
   cursor: pointer;
+  transition:
+    transform 0.08s ease,
+    box-shadow 0.08s ease;
+}
+
+#hud button:active {
+  transform: translateY(2px) scale(0.96);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 #scene {
@@ -112,6 +123,7 @@ body {
 }
 
 .panel {
+  position: relative;
   width: min(92vw, 520px);
   background: var(--panel);
   border-radius: 16px;
@@ -161,6 +173,21 @@ body {
   padding: 6px 8px;
   border-radius: 8px;
   cursor: pointer;
+  box-shadow: var(--shadow);
+  transition:
+    transform 0.08s ease,
+    box-shadow 0.08s ease;
+}
+
+.panel button:active {
+  transform: translateY(2px) scale(0.96);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+#stats #close-stats {
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }
 
 /* Oculto nativo con atributo hidden */


### PR DESCRIPTION
## Summary
- Display the HUD and reposition the stats close button at the top of the panel
- Ensure reset control is accessible and add shadows with press feedback to HUD and panel buttons

## Testing
- `npx prettier --write index.html style.css` (failed: 403 Forbidden)
- `npx prettier --check index.html style.css` (failed: 403 Forbidden)
- `npm test` (failed: package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_689acdccf45c832eb48cf2bd5a67f701