### PR TITLE
Overlay HUD on stage and use dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="manifest" href="manifest.json" />
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png" />
     <link rel="stylesheet" href="style.css" />
-    <meta name="theme-color" content="#dff4ff" />
+    <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   </head>

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "start_url": "./",
   "scope": "./",
   "display": "standalone",
-  "background_color": "#dff4ff",
-  "theme_color": "#dff4ff",
+  "background_color": "#000000",
+  "theme_color": "#000000",
   "icons": [
     {
       "src": "assets/icons/icon-192.png",

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 :root {
-  --bg: #dff4ff;
+  --bg: #000000;
   --panel: rgba(255, 255, 255, 0.85);
   --accent: #66ccff;
   --btn: #ffcc66;
@@ -26,16 +26,17 @@ body {
 }
 
 #app {
+  position: relative;
   height: 100%;
-  display: grid;
-  grid-template-rows: auto 1fr;
 }
 
 #hud {
+  position: absolute;
+  top: 8px;
+  right: 8px;
   display: flex;
-  justify-content: flex-end;
   gap: 8px;
-  padding: 8px;
+  z-index: 3;
 }
 
 #hud button {
@@ -71,7 +72,9 @@ body {
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
   height: auto;
   z-index: 2;
   pointer-events: none;
@@ -87,6 +90,7 @@ body {
   align-items: flex-end;
   gap: 12px;
   z-index: 3;
+  background: none;
 }
 
 #buttons .action {


### PR DESCRIPTION
## Summary
- Remove top HUD bar by overlaying HUD buttons on the scene
- Use black theme color in HTML and manifest
- Ensure bottom button area is transparent
- Make stage images responsive so the full image stays visible in the viewport

## Testing
- `npx prettier --check index.html style.css manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_689ad0285b44832ea815df4be76e908c