### PR TITLE
Add button color customization and stats counters

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,13 +55,11 @@
           <ul id="button-list"></ul>
           <div class="row">
             <input id="new-label" type="text" placeholder="Nombre del botón" />
+            <input id="new-color" type="color" value="#ffcc66" />
             <button id="add-button">Agregar</button>
           </div>
-          <label class="row">
-            <input id="toggle-stats" type="checkbox" />
-            Mostrar estadísticas en el HUD
-          </label>
           <div class="row">
+            <button id="toggle-counts">Mostrar contadores</button>
             <button id="reset-app">Reiniciar</button>
           </div>
           <div class="row end">

--- a/style.css
+++ b/style.css
@@ -94,6 +94,7 @@ body {
 }
 
 #buttons .action {
+  position: relative;
   --arc-y: 0px;
   width: 64px;
   height: 64px;
@@ -108,6 +109,19 @@ body {
     transform 0.08s ease,
     box-shadow 0.08s ease;
   transform: translateY(var(--arc-y));
+}
+
+#buttons .action[data-show-count="true"]::before {
+  content: attr(data-count);
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--panel);
+  color: #000000;
+  padding: 2px 6px;
+  border-radius: 8px;
+  font-size: 12px;
 }
 
 #buttons .action:active {
@@ -162,10 +176,23 @@ body {
 }
 #button-list li {
   display: grid;
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: auto 1fr auto auto;
   gap: 8px;
   align-items: center;
   padding: 6px 0;
+}
+
+.drag-handle {
+  cursor: grab;
+  user-select: none;
+}
+
+.panel input[type="color"] {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  background: none;
 }
 #button-list input {
   width: 100%;


### PR DESCRIPTION
## Summary
- allow choosing a color for each action button and apply it in the HUD
- show per-button press counts and let users toggle them on/off
- replace arrow controls with drag handles for button reordering
- always play tap sound on button press and remove action-complete cue

## Testing
- `npx prettier --check index.html app.js style.css`

------
https://chatgpt.com/codex/tasks/task_e_689b37991ee4832e9ea696aedeba597c