### PR TITLE
feat: add refresh option in settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@ const buttonList = document.getElementById("button-list");
 const toggleCounts = document.getElementById("toggle-counts");
 const closeSettings = document.getElementById("close-settings");
 const resetApp = document.getElementById("reset-app");
+const refreshApp = document.getElementById("refresh-app");
 const introVideo = document.getElementById("intro-video");
 
 let dragIndex = null;
@@ -221,6 +222,24 @@ resetApp.addEventListener("click", () => {
   if (!ok) return;
   localStorage.removeItem(LS_SETTINGS);
   localStorage.removeItem(LS_LOG);
+  location.reload();
+});
+
+refreshApp.addEventListener("click", async () => {
+  const ok = confirm("¿Actualizar la app? Se borrará la caché de la página.");
+  if (!ok) return;
+  if ("serviceWorker" in navigator) {
+    const regs = await navigator.serviceWorker.getRegistrations();
+    for (const reg of regs) {
+      await reg.unregister();
+    }
+  }
+  if (window.caches) {
+    const names = await caches.keys();
+    for (const name of names) {
+      await caches.delete(name);
+    }
+  }
   location.reload();
 });
 

--- a/index.html
+++ b/index.html
@@ -58,7 +58,8 @@
 
       <section id="settings" hidden>
         <div class="panel">
-          <h2>Botones</h2>
+          <h2>Configuración</h2>
+          <h3>Hábitos</h3>
           <ul id="button-list"></ul>
           <div class="row">
             <input id="new-label" type="text" placeholder="Nombre del botón" />
@@ -68,6 +69,7 @@
           <div class="row">
             <button id="toggle-counts">Mostrar contadores</button>
             <button id="reset-app">Reiniciar</button>
+            <button id="refresh-app">Actualizar</button>
           </div>
           <div class="row end">
             <button id="close-settings">Cerrar</button>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "habit",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "prettier": "^3.3.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add refresh button that clears service worker cache and reloads app
- retitle settings menu to "Configuración" with "Hábitos" subheading
- add package.json with placeholder test script and Prettier config

## Testing
- `npx prettier --check package.json`
- `npm test`
- `npm install --save-dev prettier@^3` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b993ed418832eb235ea789af39880