### PR TITLE
feat: enhance UX and offline support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -49,21 +49,38 @@
       <section id="stats" hidden>
         <div class="panel">
           <button id="close-stats" class="close" aria-label="Cerrar">✕</button>
-          <div><strong>Hoy:</strong> <span id="stat-today">0</span></div>
-          <div><strong>Semana:</strong> <span id="stat-week">0</span></div>
-          <div><strong>Mes:</strong> <span id="stat-month">0</span></div>
-          <div><strong>Total:</strong> <span id="stat-total">0</span></div>
+          <div>
+            <strong id="lbl-today">Hoy:</strong> <span id="stat-today">0</span>
+          </div>
+          <div>
+            <strong id="lbl-week">Semana:</strong> <span id="stat-week">0</span>
+          </div>
+          <div>
+            <strong id="lbl-month">Mes:</strong> <span id="stat-month">0</span>
+          </div>
+          <div>
+            <strong id="lbl-total">Total:</strong>
+            <span id="stat-total">0</span>
+          </div>
+          <canvas id="chart-week" width="300" height="150"></canvas>
         </div>
       </section>
 
       <section id="settings" hidden>
         <div class="panel">
-          <h2>Configuración</h2>
-          <h3>Hábitos</h3>
+          <h2 id="settings-title">Configuración</h2>
+          <h3 id="settings-habits">Hábitos</h3>
           <ul id="button-list"></ul>
           <div class="row">
             <input id="new-label" type="text" placeholder="Nombre del botón" />
+            <input id="new-icon" type="text" placeholder="😀" />
             <input id="new-color" type="color" value="#ffcc66" />
+            <button
+              id="new-preview"
+              class="action"
+              type="button"
+              disabled
+            ></button>
             <button id="add-button">Agregar</button>
           </div>
           <div class="row">
@@ -74,6 +91,21 @@
           <div class="row end">
             <button id="close-settings">Cerrar</button>
           </div>
+        </div>
+      </section>
+
+      <section id="onboarding" hidden>
+        <div class="panel">
+          <p id="onboarding-text"></p>
+          <div class="row end">
+            <button id="close-onboarding">OK</button>
+          </div>
+        </div>
+      </section>
+
+      <section id="storage-error" hidden>
+        <div class="panel">
+          <p id="storage-error-text"></p>
         </div>
       </section>
     </div>

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div
+      class="panel"
+      style="margin: 20px auto; max-width: 400px; text-align: center"
+    >
+      <p>You are offline.<br />Estás desconectado.</p>
+    </div>
+  </body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,6 +2,7 @@ const CACHE = "habit-reinforcer-v2";
 const ASSETS = [
   "./",
   "./index.html",
+  "./offline.html",
   "./style.css",
   "./app.js",
   "./manifest.json",
@@ -36,5 +37,20 @@ self.addEventListener("activate", (e) => {
 });
 
 self.addEventListener("fetch", (e) => {
-  e.respondWith(caches.match(e.request).then((r) => r || fetch(e.request)));
+  e.respondWith(
+    fetch(e.request)
+      .then((res) => {
+        const copy = res.clone();
+        caches.open(CACHE).then((c) => c.put(e.request, copy));
+        return res;
+      })
+      .catch(() =>
+        caches.match(e.request).then((r) => {
+          if (r) return r;
+          if (e.request.mode === "navigate") {
+            return caches.match("./offline.html");
+          }
+        }),
+      ),
+  );
 });

--- a/style.css
+++ b/style.css
@@ -95,6 +95,8 @@ body {
   bottom: calc(18px + 40px);
   transform: translateX(-50%);
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   align-items: flex-end;
   gap: 12px;
   z-index: 3;
@@ -117,8 +119,9 @@ body {
   cursor: pointer;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
   transition:
-    transform 0.08s ease,
-    box-shadow 0.08s ease;
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.3s ease;
   transform: translateY(var(--arc-y));
 }
 
@@ -129,7 +132,9 @@ body {
 
 /* Paneles superpuestos */
 #stats,
-#settings {
+#settings,
+#onboarding,
+#storage-error {
   position: absolute;
   inset: 0;
   display: grid;
@@ -174,7 +179,7 @@ body {
 }
 #button-list li {
   display: grid;
-  grid-template-columns: auto 1fr auto auto;
+  grid-template-columns: auto 1fr auto auto auto auto;
   gap: 8px;
   align-items: center;
   padding: 6px 0;
@@ -194,6 +199,12 @@ body {
 }
 #button-list input {
   width: 100%;
+}
+.panel .action {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 .panel button {
   border: 0;
@@ -217,6 +228,29 @@ body {
   position: absolute;
   top: 8px;
   right: 8px;
+}
+
+@keyframes float {
+  0% {
+    transform: translate(-50%, -50%) translateY(0);
+  }
+  50% {
+    transform: translate(-50%, -50%) translateY(-4px);
+  }
+  100% {
+    transform: translate(-50%, -50%) translateY(0);
+  }
+}
+
+#creature {
+  animation: float 6s ease-in-out infinite;
+}
+
+@media (min-width: 600px) {
+  #buttons .action {
+    width: 72px;
+    height: 72px;
+  }
 }
 
 /* Oculto nativo con atributo hidden */


### PR DESCRIPTION
## Summary
- add onboarding, localization, and icon previews for habits
- show weekly bar chart and improve responsive layout
- expand service worker caching with custom offline page and storage fallbacks

## Testing
- `npx prettier --check index.html style.css app.js service-worker.js offline.html`

------
https://chatgpt.com/codex/tasks/task_e_689ba24b5c20832e85acbbfcdd15ce78