### PR TITLE
Show button counters on separate line, auto-style new buttons, fade intro video early, and add main background

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,9 +62,20 @@ const defaultSettings = {
   stage: 1,
   stageProgress: 0,
 };
+const LABEL_LIMIT = 10;
+const defaultColors = [
+  "#ffcc66",
+  "#66ff66",
+  "#66ccff",
+  "#ff6666",
+  "#cc66ff",
+  "#ff9966",
+];
+const defaultEmojis = ["😀", "💪", "📚", "🍎", "🧘", "🚰"];
 
 let settings = loadJSON(LS_SETTINGS, defaultSettings);
 let logs = loadJSON(LS_LOG, []);
+let nextDefault = settings.buttons.length;
 const thresholds = [2, 3, 4, 5, 6]; // 1→2, 2→3, 3→4, 4→5, 5→6
 
 // Elementos
@@ -89,6 +100,7 @@ const newIcon = document.getElementById("new-icon");
 const newColor = document.getElementById("new-color");
 const newPreview = document.getElementById("new-preview");
 const buttonList = document.getElementById("button-list");
+newLabel.maxLength = LABEL_LIMIT;
 const toggleCounts = document.getElementById("toggle-counts");
 const closeSettings = document.getElementById("close-settings");
 const resetApp = document.getElementById("reset-app");
@@ -140,9 +152,19 @@ renderButtons();
 renderSettings();
 updateStats();
 if (introVideo) {
-  setTimeout(() => {
-    introVideo.remove();
-  }, 3000);
+  const removeVideo = () => {
+    introVideo.classList.add("fade-out");
+    setTimeout(() => introVideo.remove(), 500);
+  };
+  introVideo.addEventListener("timeupdate", () => {
+    if (
+      introVideo.duration - introVideo.currentTime <= 0.5 &&
+      !introVideo.classList.contains("fade-out")
+    ) {
+      removeVideo();
+    }
+  });
+  introVideo.addEventListener("ended", removeVideo);
 }
 
 if (!loadJSON(LS_ONBOARD, false)) {
@@ -198,8 +220,16 @@ function renderButtons() {
     const btn = document.createElement("button");
     btn.className = "action";
     const count = counts[b.label] || 0;
-    const base = settings.showButtonCounts ? `${b.label} ${count}` : b.label;
-    btn.textContent = `${b.icon ? b.icon + " " : ""}${base}`;
+    const labelSpan = document.createElement("span");
+    labelSpan.className = "label";
+    labelSpan.textContent = `${b.icon ? b.icon + " " : ""}${b.label}`;
+    btn.appendChild(labelSpan);
+    if (settings.showButtonCounts) {
+      const countSpan = document.createElement("span");
+      countSpan.className = "count";
+      countSpan.textContent = String(count);
+      btn.appendChild(countSpan);
+    }
     btn.style.background = b.color || "#ffcc66";
     btn.addEventListener("click", () => handleAction(b.label));
     buttonsEl.appendChild(btn);
@@ -336,18 +366,24 @@ function updateNewPreview() {
 [newLabel, newIcon, newColor].forEach((el) =>
   el.addEventListener("input", updateNewPreview),
 );
-updateNewPreview();
+
+function setNextDefaults() {
+  newColor.value = defaultColors[nextDefault % defaultColors.length];
+  newIcon.value = defaultEmojis[nextDefault % defaultEmojis.length];
+  nextDefault += 1;
+  updateNewPreview();
+}
+
+setNextDefaults();
 
 addButton.addEventListener("click", () => {
-  const label = newLabel.value.trim();
+  const label = newLabel.value.trim().slice(0, LABEL_LIMIT);
   if (!label) return;
   const color = newColor.value;
   const icon = newIcon.value.trim();
   settings.buttons.push({ label, color, icon });
   newLabel.value = "";
-  newIcon.value = "";
-  newColor.value = "#ffcc66";
-  updateNewPreview();
+  setNextDefaults();
   saveJSON(LS_SETTINGS, settings);
   renderSettings();
   renderButtons();
@@ -417,6 +453,7 @@ function renderSettings() {
     const input = document.createElement("input");
     input.type = "text";
     input.value = b.label;
+    input.maxLength = LABEL_LIMIT;
     input.addEventListener("input", () => {
       settings.buttons[idx].label = input.value;
       saveJSON(LS_SETTINGS, settings);

--- a/style.css
+++ b/style.css
@@ -32,6 +32,11 @@ body {
   height: 100%;
   object-fit: cover;
   z-index: 10;
+  transition: opacity 0.5s ease;
+}
+
+#intro-video.fade-out {
+  opacity: 0;
 }
 
 #app {
@@ -69,6 +74,7 @@ body {
   position: relative;
   height: 100%;
   overflow: hidden;
+  background: url("assets/images/background.png") center/cover no-repeat;
 }
 
 #environment {
@@ -109,6 +115,7 @@ body {
   width: 64px;
   height: 64px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   border-radius: 50%;
@@ -123,6 +130,15 @@ body {
     box-shadow 0.2s ease,
     background 0.3s ease;
   transform: translateY(var(--arc-y));
+}
+#buttons .action .label {
+  text-align: center;
+}
+
+#buttons .action .count {
+  margin-top: 2px;
+  font-size: 14px;
+  text-align: center;
 }
 
 #buttons .action:active {
@@ -205,6 +221,7 @@ body {
   height: 40px;
   padding: 0;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  flex-direction: row;
 }
 .panel button {
   border: 0;


### PR DESCRIPTION
## Summary
- Display button press counts on a centered new line within each habit button and cycle new button colors/emojis with label limits
- Fade intro video half a second before ending for a seamless transition
- Reference a background image behind stage assets; placeholder binary removed and service worker cache list updated

## Testing
- `npx prettier --write service-worker.js`
- `npx prettier --check service-worker.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bab5f9d34832ead79839a1a776816