### PR TITLE
Improve intro video, background, and emoji picker

### DIFF
--- a/app.js
+++ b/app.js
@@ -126,6 +126,16 @@ function setNextDefaults() {
 }
 setNextDefaults();
 
+newIcon.addEventListener("click", () => {
+  if (newIcon.showPicker) {
+    newIcon.showPicker();
+  }
+});
+
+newIcon.addEventListener("input", () => {
+  newIcon.value = [...newIcon.value][0] || "";
+});
+
 let dragIndex = null;
 document.addEventListener("pointerup", () => {
   dragIndex = null;
@@ -161,9 +171,14 @@ updateStats();
 if (introVideo) {
   introVideo.removeAttribute("controls");
   introVideo.play().catch(() => {});
-  setTimeout(() => {
+  introVideo.addEventListener("timeupdate", () => {
+    if (introVideo.duration - introVideo.currentTime <= 0.3) {
+      introVideo.classList.add("fade-out");
+    }
+  });
+  introVideo.addEventListener("ended", () => {
     introVideo.remove();
-  }, 3000);
+  });
 }
 
 if (!loadJSON(LS_ONBOARD, false)) {
@@ -362,7 +377,7 @@ addButton.addEventListener("click", () => {
   const label = newLabel.value.trim().slice(0, LABEL_LIMIT);
   if (!label) return;
   const color = newColor.value;
-  const icon = newIcon.value.trim();
+  const icon = [...newIcon.value.trim()][0] || "";
   settings.buttons.push({ label, color, icon });
   newLabel.value = "";
   setNextDefaults();

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
           <ul id="button-list"></ul>
           <div class="row">
             <input id="new-label" type="text" placeholder="Nombre del botón" />
-            <input id="new-icon" type="text" placeholder="😀" />
+            <input id="new-icon" type="text" value="😀" readonly />
             <input id="new-color" type="color" value="#ffcc66" />
             <button id="add-button">Agregar</button>
           </div>

--- a/style.css
+++ b/style.css
@@ -32,6 +32,12 @@ body {
   height: 100%;
   object-fit: cover;
   z-index: 10;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+#intro-video.fade-out {
+  opacity: 0;
 }
 
 #app {
@@ -69,6 +75,7 @@ body {
   position: relative;
   height: 100%;
   overflow: hidden;
+  background: url("background.png") center / cover no-repeat;
 }
 
 #environment {


### PR DESCRIPTION
## Summary
- Fade intro video out before removing and autoplay without controls
- Fill main scene with provided background image
- Open system emoji picker when adding new habits

## Testing
- `npx prettier --check index.html style.css app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcdb966f4832eb0ca1c8037b75725