### PR TITLE
Replace stage 1 image with looping video

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,7 +95,7 @@ let notes = loadJSON(LS_NOTES, {});
 const thresholds = [2, 3, 4, 5, 6]; // 1→2, 2→3, 3→4, 4→5, 5→6
 
 // Elementos
-const creatureEl = document.getElementById("creature");
+let creatureEl = document.getElementById("creature");
 const envEl = document.getElementById("environment");
 const buttonsEl = document.getElementById("buttons");
 const hudStatsBtn = document.getElementById("btn-stats");
@@ -328,7 +328,32 @@ function renderButtons() {
 
 function renderStage() {
   const s = settings.stage;
-  creatureEl.src = `assets/images/stage${s}.png`;
+  if (s === 1) {
+    if (creatureEl.tagName !== "VIDEO") {
+      const video = document.createElement("video");
+      video.id = "creature";
+      video.autoplay = true;
+      video.loop = true;
+      video.muted = true;
+      video.playsInline = true;
+      video.src = "assets/videos/stage1.mp4";
+      creatureEl.replaceWith(video);
+      creatureEl = video;
+    } else {
+      creatureEl.src = "assets/videos/stage1.mp4";
+    }
+  } else {
+    if (creatureEl.tagName !== "IMG") {
+      const img = document.createElement("img");
+      img.id = "creature";
+      img.alt = "Criatura";
+      img.src = `assets/images/stage${s}.png`;
+      creatureEl.replaceWith(img);
+      creatureEl = img;
+    } else {
+      creatureEl.src = `assets/images/stage${s}.png`;
+    }
+  }
 }
 
 function playTapSound() {

--- a/index.html
+++ b/index.html
@@ -32,7 +32,14 @@
 
       <main id="scene">
         <div id="environment"></div>
-        <img id="creature" alt="Criatura" src="assets/images/stage1.png" />
+        <video
+          id="creature"
+          src="assets/videos/stage1.mp4"
+          autoplay
+          loop
+          muted
+          playsinline
+        ></video>
         <div id="buttons"></div>
       </main>
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -9,7 +9,7 @@ const ASSETS = [
   "./assets/icons/icon-192.png",
   "./assets/icons/icon-512.png",
   "./assets/images/background.png",
-  "./assets/images/stage1.png",
+  "./assets/videos/stage1.mp4",
   "./assets/images/stage2.png",
   "./assets/images/stage3.png",
   "./assets/images/stage4.png",


### PR DESCRIPTION
## Summary
- Show stage 1 creature using an autoplaying, looping video
- Swap between video and images when creature evolves
- Cache new video asset in service worker

## Testing
- `npx prettier --check index.html app.js service-worker.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6f139288832eb39159cd74978a4c