### PR TITLE
Sync new-button color picker with last chosen color

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,12 +163,13 @@ for (const [name, url] of Object.entries(soundFiles)) {
   loadSound(name, url);
 }
 
-let nextDefault = settings.buttons.length;
-function setNextDefaults() {
-  newColor.value = defaultColors[nextDefault % defaultColors.length];
-  nextDefault += 1;
-}
-setNextDefaults();
+let lastColor = settings.buttons.length
+  ? settings.buttons[settings.buttons.length - 1].color
+  : defaultColors[0];
+newColor.value = lastColor;
+newColor.addEventListener("input", () => {
+  lastColor = newColor.value;
+});
 
 let dragIndex = null;
 document.addEventListener("pointerup", () => {
@@ -502,7 +503,6 @@ addButton.addEventListener("click", () => {
   const color = newColor.value;
   settings.buttons.push({ label, color });
   newLabel.value = "";
-  setNextDefaults();
   saveJSON(LS_SETTINGS, settings);
   renderSettings();
   renderButtons();
@@ -591,6 +591,8 @@ function renderSettings() {
       settings.buttons[idx].color = color.value;
       saveJSON(LS_SETTINGS, settings);
       renderButtons();
+      lastColor = color.value;
+      newColor.value = lastColor;
     });
 
     const del = document.createElement("button");


### PR DESCRIPTION
## Summary
- Track the most recently selected color across color pickers
- Auto-update the "new button" color picker with the last chosen color

## Testing
- `npx prettier --check app.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689de0d762b0832eb6976fe809e09c08