### PR TITLE
Fix intro autoplay and add stage1 MP4 fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -221,8 +221,13 @@ renderButtons();
 renderSettings();
 updateStats();
 if (introVideo) {
+  introVideo.autoplay = true;
+  introVideo.muted = true;
+  introVideo.playsInline = true;
   introVideo.removeAttribute("controls");
-  introVideo.play().catch(() => {});
+  const playIntro = () => introVideo.play().catch(() => {});
+  introVideo.addEventListener("canplay", playIntro, { once: true });
+  playIntro();
   introVideo.addEventListener("ended", () => {
     introVideo.classList.add("fade-out");
     introVideo.addEventListener(
@@ -327,6 +332,20 @@ function renderButtons() {
   applyBottomArc(buttonsEl);
 }
 
+function setStageOneSources(video) {
+  video.innerHTML = "";
+  const sources = [
+    { src: "assets/videos/stage1.mp4", type: "video/mp4" },
+    { src: "assets/videos/stage1.mov", type: "video/quicktime" },
+  ];
+  for (const { src, type } of sources) {
+    const source = document.createElement("source");
+    source.src = src;
+    source.type = type;
+    video.appendChild(source);
+  }
+}
+
 function renderStage() {
   const s = settings.stage;
   if (s === 1) {
@@ -337,11 +356,11 @@ function renderStage() {
       video.loop = true;
       video.muted = true;
       video.playsInline = true;
-      video.src = "assets/videos/stage1.mp4";
+      setStageOneSources(video);
       creatureEl.replaceWith(video);
       creatureEl = video;
     } else {
-      creatureEl.src = "assets/videos/stage1.mp4";
+      setStageOneSources(creatureEl);
     }
     creatureEl.play().catch(() => {});
   } else {

--- a/index.html
+++ b/index.html
@@ -32,14 +32,10 @@
 
       <main id="scene">
         <div id="environment"></div>
-        <video
-          id="creature"
-          src="assets/videos/stage1.mp4"
-          autoplay
-          loop
-          muted
-          playsinline
-        ></video>
+        <video id="creature" autoplay loop muted playsinline>
+          <source src="assets/videos/stage1.mp4" type="video/mp4" />
+          <source src="assets/videos/stage1.mov" type="video/quicktime" />
+        </video>
         <div id="buttons"></div>
       </main>
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE = "habit-reinforcer-v4";
+const CACHE = "habit-reinforcer-v6";
 const ASSETS = [
   "./",
   "./index.html",
@@ -10,6 +10,7 @@ const ASSETS = [
   "./assets/icons/icon-512.png",
   "./assets/images/background.png",
   "./assets/videos/stage1.mp4",
+  "./assets/videos/stage1.mov",
   "./assets/images/stage2.png",
   "./assets/images/stage3.png",
   "./assets/images/stage4.png",


### PR DESCRIPTION
## Summary
- ensure intro video plays automatically on all platforms
- add MP4 fallback for stage1 video and update service worker cache

## Testing
- `npx prettier --check app.js index.html service-worker.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eb235a540832e92c8e0c80af2a158