### PR TITLE
fix: left-align stats dropdown and limit chart labels

### DIFF
--- a/app.js
+++ b/app.js
@@ -647,6 +647,9 @@ function drawChart() {
   ctx.rotate(-Math.PI / 2);
   ctx.fillText(t("entries"), 0, 0);
   ctx.restore();
+  const sampleLabel = String(data.length - 1 + labelOffset);
+  const labelWidth = ctx.measureText(sampleLabel).width + 4;
+  const step = Math.max(1, Math.ceil(labelWidth / barWidth));
   data.forEach((val, i) => {
     const barHeight = (val / max) * (originY - 10);
     const x = marginLeft + i * barWidth;
@@ -654,7 +657,9 @@ function drawChart() {
     ctx.fillRect(x + 4, originY - barHeight, barWidth - 8, barHeight);
     ctx.fillStyle = "#000000";
     const label = String(i + labelOffset);
-    ctx.fillText(label, x + barWidth / 2, h - marginBottom + 15);
+    if (i % step === 0 || i === data.length - 1) {
+      ctx.fillText(label, x + barWidth / 2, h - marginBottom + 15);
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -224,7 +224,14 @@ body {
 
 #stats select {
   margin-top: 10px;
-  width: 100%;
+  width: auto;
+  align-self: flex-start;
+  padding: 4px 8px;
+  font-weight: 600;
+  font-size: 1.1em;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #000000;
 }
 
 .row {


### PR DESCRIPTION
## Summary
- Left-align stats dropdown for consistent layout
- Limit chart labels to prevent overlap

## Testing
- `npx prettier --write style.css app.js`
- `npx prettier --check style.css app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a091956048832e8575f4704858c37e