### PR TITLE
Use top close button for settings menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -250,7 +250,7 @@ newLabel.placeholder = t("buttonName");
 addButton.textContent = t("add");
 resetApp.textContent = t("reset");
 refreshApp.textContent = t("refresh");
-closeSettings.textContent = t("close");
+closeSettings.setAttribute("aria-label", t("close"));
 closeNote.setAttribute("aria-label", t("close"));
 statsHeading.textContent = t("stats");
 lblToday.textContent = `${t("today")}:`;

--- a/index.html
+++ b/index.html
@@ -73,6 +73,9 @@
 
       <section id="settings" hidden>
         <div class="panel">
+          <button id="close-settings" class="close" aria-label="Cerrar">
+            ✕
+          </button>
           <h2 id="settings-title">Configuración</h2>
           <h3 id="settings-habits">Hábitos</h3>
           <ul id="button-list"></ul>
@@ -101,9 +104,6 @@
           <div class="row">
             <button id="reset-app">Renacer</button>
             <button id="refresh-app">Borrar Cache</button>
-          </div>
-          <div class="row end">
-            <button id="close-settings">Cerrar</button>
           </div>
         </div>
       </section>

--- a/style.css
+++ b/style.css
@@ -365,6 +365,12 @@ body {
   right: 8px;
 }
 
+#settings #close-settings {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
 #note-sheet #close-note {
   position: absolute;
   top: 8px;


### PR DESCRIPTION
## Summary
- Move settings menu close action to an "X" button at the top of the panel
- Position the new close button with CSS and translate its aria-label

## Testing
- `npx prettier --check index.html app.js style.css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16b6e7c34832ebe1e5757edb54e2d