### PR TITLE
Scale videos to cover screen and remove white startup flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
     <link rel="manifest" href="manifest.json" />
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png" />
     <link rel="stylesheet" href="style.css" />
+    <style>
+      html,
+      body {
+        background: #000000;
+      }
+    </style>
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/offline.html
+++ b/offline.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Offline</title>
     <link rel="stylesheet" href="style.css" />
+    <style>
+      html,
+      body {
+        background: #000000;
+      }
+    </style>
   </head>
   <body>
     <div

--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ body {
   inset: 0;
   width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
   background: #000000;
   z-index: 10;
   opacity: 1;
@@ -110,11 +110,9 @@ body {
 #creature {
   position: absolute;
   inset: 0;
-  margin: auto;
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   z-index: 2;
   pointer-events: none;
   user-select: none;


### PR DESCRIPTION
## Summary
- Ensure intro and creature videos use `object-fit: cover` so 480×720 footage fills the screen with minimal side cropping
- Add inline black backgrounds to HTML and offline pages to avoid white flash on PWA launch

## Testing
- `npx prettier --check index.html offline.html style.css`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2091dfbac832e928a183b0aa584be