### PR TITLE
Use eye icons for visibility toggles

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,6 +154,11 @@ const toggleCounts = document.getElementById("toggle-counts");
 const lblCounts = document.getElementById("lbl-counts");
 const toggleProgress = document.getElementById("toggle-progress");
 const lblProgress = document.getElementById("lbl-progress");
+
+function setVisibilityIcon(btn, visible) {
+  const icon = visible ? "ojo-visible" : "ojo-novisible";
+  btn.innerHTML = `<img src="assets/icons/${icon}.png" alt="" width="24" height="24" />`;
+}
 const closeSettings = document.getElementById("close-settings");
 const resetApp = document.getElementById("reset-app");
 const refreshApp = document.getElementById("refresh-app");
@@ -266,14 +271,14 @@ chartRange.innerHTML = `
 chartRange.value = "month";
 chartRange.addEventListener("change", drawChart);
 lblCounts.textContent = t("counts");
-toggleCounts.textContent = "👁️";
+setVisibilityIcon(toggleCounts, settings.showButtonCounts);
 toggleCounts.classList.toggle("off", !settings.showButtonCounts);
 toggleCounts.setAttribute(
   "aria-label",
   settings.showButtonCounts ? t("hideCounts") : t("showCounts"),
 );
 lblProgress.textContent = t("progress");
-toggleProgress.textContent = "👁️";
+setVisibilityIcon(toggleProgress, settings.showProgressCounter);
 toggleProgress.classList.toggle("off", !settings.showProgressCounter);
 toggleProgress.setAttribute(
   "aria-label",
@@ -744,6 +749,7 @@ toggleCounts.addEventListener("click", () => {
     "aria-label",
     settings.showButtonCounts ? t("hideCounts") : t("showCounts"),
   );
+  setVisibilityIcon(toggleCounts, settings.showButtonCounts);
   renderButtons();
 });
 
@@ -755,6 +761,7 @@ toggleProgress.addEventListener("click", () => {
     "aria-label",
     settings.showProgressCounter ? t("hideProgress") : t("showProgress"),
   );
+  setVisibilityIcon(toggleProgress, settings.showProgressCounter);
   updateProgressCounter();
 });
 
@@ -810,14 +817,14 @@ notePlus.addEventListener("click", () => {
 
 function renderSettings() {
   lblCounts.textContent = t("counts");
-  toggleCounts.textContent = "👁️";
+  setVisibilityIcon(toggleCounts, settings.showButtonCounts);
   toggleCounts.classList.toggle("off", !settings.showButtonCounts);
   toggleCounts.setAttribute(
     "aria-label",
     settings.showButtonCounts ? t("hideCounts") : t("showCounts"),
   );
   lblProgress.textContent = t("progress");
-  toggleProgress.textContent = "👁️";
+  setVisibilityIcon(toggleProgress, settings.showProgressCounter);
   toggleProgress.classList.toggle("off", !settings.showProgressCounter);
   toggleProgress.setAttribute(
     "aria-label",

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
           <div class="row">
             <span id="lbl-counts">Contadores</span>
             <button id="toggle-counts" aria-label="Ocultar contadores">
-              👁️
+              <img src="assets/icons/ojo-visible.png" alt="" />
             </button>
           </div>
           <div class="row">
@@ -103,7 +103,7 @@
               class="off"
               aria-label="Mostrar progreso"
             >
-              👁️
+              <img src="assets/icons/ojo-novisible.png" alt="" />
             </button>
           </div>
           <h3 id="settings-advanced">Avanzado</h3>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE = "habit-reinforcer-v5";
+const CACHE = "habit-reinforcer-v6";
 const ASSETS = [
   "./",
   "./index.html",
@@ -8,6 +8,8 @@ const ASSETS = [
   "./manifest.json",
   "./assets/icons/icon-192.png",
   "./assets/icons/icon-512.png",
+  "./assets/icons/ojo-visible.png",
+  "./assets/icons/ojo-novisible.png",
   "./assets/images/background.png",
   "./assets/videos/stage1.mov",
   "./assets/images/stage2.png",

--- a/style.css
+++ b/style.css
@@ -331,8 +331,9 @@ body {
   color: inherit;
   padding: 0;
   box-shadow: none;
-  font-size: 24px;
   position: relative;
+  width: 24px;
+  height: 24px;
 }
 
 #toggle-counts:hover,
@@ -343,18 +344,11 @@ body {
   box-shadow: none;
 }
 
-#toggle-counts.off::after,
-#toggle-progress.off::after {
-  content: "🚫";
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: none;
+#toggle-counts img,
+#toggle-progress img {
+  width: 24px;
+  height: 24px;
+  display: block;
 }
 
 #stats #close-stats {


### PR DESCRIPTION
## Summary
- replace visibility emojis with `ojo-visible` and `ojo-novisible` PNG icons
- size toggle icons via CSS for consistent layout
- precache new icons in the service worker

## Testing
- `npx prettier --write index.html style.css app.js service-worker.js`
- `npx prettier --check index.html style.css app.js service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68a20f30802c832eb83ffb8412c15f2e