### PR TITLE
Align progress toggle with counts and restore yellow default

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,7 +93,7 @@ const uuid = () =>
     : String(Date.now() + Math.random());
 
 const defaultSettings = {
-  buttons: [{ id: uuid(), label: t("defaultButton"), color: "#3366cc" }],
+  buttons: [{ id: uuid(), label: t("defaultButton"), color: "#ffcc00" }],
   showButtonCounts: true,
   showProgressCounter: false,
   stage: 1,
@@ -103,7 +103,7 @@ const defaultSettings = {
 const LABEL_LIMIT = 8;
 const MAX_BUTTONS = 5;
 const defaultColors = [
-  "#3366cc",
+  "#ffcc00",
   "#66ff66",
   "#66ccff",
   "#ff6666",
@@ -438,7 +438,7 @@ function renderButtons() {
       btn.appendChild(countSpan);
     }
 
-    btn.style.background = b.color || "#3366cc";
+    btn.style.background = b.color || "#ffcc00";
     let holdTimeout;
     let held = false;
     btn.addEventListener("pointerdown", (e) => {
@@ -856,7 +856,7 @@ function renderSettings() {
 
     const color = document.createElement("input");
     color.type = "color";
-    color.value = b.color || "#3366cc";
+    color.value = b.color || "#ffcc00";
     color.addEventListener("input", () => {
       settings.buttons[idx].color = color.value;
       saveJSON(LS_SETTINGS, settings);

--- a/index.html
+++ b/index.html
@@ -87,16 +87,14 @@
           <ul id="button-list"></ul>
           <div class="row">
             <input id="new-label" type="text" placeholder="Nombre del botón" />
-            <input id="new-color" type="color" value="#3366cc" />
+            <input id="new-color" type="color" value="#ffcc00" />
             <button id="add-button">Agregar</button>
           </div>
-          <div class="row">
+          <div class="row" id="visibility-row">
             <span id="lbl-counts">Contadores</span>
             <button id="toggle-counts" aria-label="Ocultar contadores">
               <img src="assets/icons/ojo-visible.png" alt="" />
             </button>
-          </div>
-          <div class="row">
             <span id="lbl-progress">Progreso</span>
             <button
               id="toggle-progress"

--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 :root {
   --bg: #000000;
   --panel: rgba(255, 255, 255, 0.85);
-  --accent: #3366cc;
-  --btn: #3366cc;
+  --accent: #ffcc00;
+  --btn: #ffcc00;
   --shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
 }
 
@@ -256,6 +256,10 @@ body {
   justify-content: flex-end;
 }
 
+#visibility-row {
+  flex-wrap: nowrap;
+}
+
 .row input[type="text"] {
   flex: 1;
   min-width: 0;
@@ -332,8 +336,10 @@ body {
   padding: 0;
   box-shadow: none;
   position: relative;
-  width: 24px;
   height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #toggle-counts:hover,
@@ -346,8 +352,8 @@ body {
 
 #toggle-counts img,
 #toggle-progress img {
-  width: 24px;
-  height: 24px;
+  height: 100%;
+  width: auto;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- Align progress visibility toggle next to contadores and let eye icons render at natural size
- Reinstate original yellow as default habit button color

## Testing
- `npx prettier --check index.html style.css app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21733d16c832e9f6b89a4755a0e3c