### PR TITLE
Refine menu spacing and restore button colors

### DIFF
--- a/app.js
+++ b/app.js
@@ -438,7 +438,7 @@ function renderButtons() {
       btn.appendChild(countSpan);
     }
 
-    btn.style.background = b.color || "#ffcc00";
+    btn.style.setProperty("--btn", b.color || "#ffcc00");
     let holdTimeout;
     let held = false;
     btn.addEventListener("pointerdown", (e) => {

--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ body {
 #hud button {
   font-size: 18px;
   border: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: #0066ff;
   padding: 6px 10px;
   border-radius: 10px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
@@ -74,7 +74,7 @@ body {
 }
 
 #hud button:hover {
-  background: rgba(0, 0, 0, 0.6);
+  background: #0050cc;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
 }
 
@@ -258,6 +258,15 @@ body {
 
 #visibility-row {
   flex-wrap: nowrap;
+}
+
+#lbl-progress {
+  margin-left: 16px;
+}
+
+#visibility-row button img {
+  width: 20px;
+  height: 20px;
 }
 
 .row input[type="text"] {


### PR DESCRIPTION
## Summary
- Add left margin before progress label in settings
- Shrink visibility eye icons
- Restore blue HUD buttons and yellow habit button styling

## Testing
- `npx prettier --check style.css app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a224451864832e8551fcf8b2811b70