### PR TITLE
Play stage2 video for later creature stages

### DIFF
--- a/app.js
+++ b/app.js
@@ -468,48 +468,37 @@ function renderButtons() {
 
 function renderStage() {
   const s = settings.stage;
-  if (s === 1) {
-    if (creatureEl.tagName !== "VIDEO") {
-      const video = document.createElement("video");
-      video.id = "creature";
-      video.autoplay = true;
-      video.loop = true;
-      video.muted = true;
-      video.setAttribute("muted", "");
-      video.playsInline = true;
-      video.setAttribute("playsinline", "");
-      video.setAttribute("webkit-playsinline", "");
-      video.src = "assets/videos/stage1.mov";
-      creatureEl.replaceWith(video);
-      creatureEl = video;
-    } else {
-      creatureEl.src = "assets/videos/stage1.mov";
-      creatureEl.muted = true;
-      creatureEl.setAttribute("muted", "");
-      creatureEl.setAttribute("playsinline", "");
-      creatureEl.setAttribute("webkit-playsinline", "");
-      creatureEl.autoplay = true;
-      creatureEl.loop = true;
-    }
-    const playCreature = () => creatureEl.play().catch(() => {});
-    if (creatureEl.readyState >= 2) {
-      playCreature();
-    } else {
-      creatureEl.addEventListener("canplay", playCreature, { once: true });
-    }
-    document.addEventListener("pointerdown", playCreature, { once: true });
+  const videoSrc =
+    s === 1 ? "assets/videos/stage1.mov" : "assets/videos/stage2.mov";
+  if (creatureEl.tagName !== "VIDEO") {
+    const video = document.createElement("video");
+    video.id = "creature";
+    video.autoplay = true;
+    video.loop = true;
+    video.muted = true;
+    video.setAttribute("muted", "");
+    video.playsInline = true;
+    video.setAttribute("playsinline", "");
+    video.setAttribute("webkit-playsinline", "");
+    video.src = videoSrc;
+    creatureEl.replaceWith(video);
+    creatureEl = video;
   } else {
-    if (creatureEl.tagName !== "IMG") {
-      const img = document.createElement("img");
-      img.id = "creature";
-      img.alt = "Criatura";
-      img.src = `assets/images/stage${s}.png`;
-      creatureEl.replaceWith(img);
-      creatureEl = img;
-    } else {
-      creatureEl.src = `assets/images/stage${s}.png`;
-    }
+    creatureEl.src = videoSrc;
+    creatureEl.muted = true;
+    creatureEl.setAttribute("muted", "");
+    creatureEl.setAttribute("playsinline", "");
+    creatureEl.setAttribute("webkit-playsinline", "");
+    creatureEl.autoplay = true;
+    creatureEl.loop = true;
   }
+  const playCreature = () => creatureEl.play().catch(() => {});
+  if (creatureEl.readyState >= 2) {
+    playCreature();
+  } else {
+    creatureEl.addEventListener("canplay", playCreature, { once: true });
+  }
+  document.addEventListener("pointerdown", playCreature, { once: true });
 }
 
 function playTapSound() {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE = "habit-reinforcer-v6";
+const CACHE = "habit-reinforcer-v7";
 const ASSETS = [
   "./",
   "./index.html",
@@ -12,11 +12,7 @@ const ASSETS = [
   "./assets/icons/ojo-novisible.png",
   "./assets/images/background.png",
   "./assets/videos/stage1.mov",
-  "./assets/images/stage2.png",
-  "./assets/images/stage3.png",
-  "./assets/images/stage4.png",
-  "./assets/images/stage5.png",
-  "./assets/images/stage6.png",
+  "./assets/videos/stage2.mov",
   "./assets/sounds/tap.wav",
   "./assets/sounds/stage-change.wav",
   "./assets/sounds/action-complete.wav",


### PR DESCRIPTION
## Summary
- use video for all stages, selecting stage2.mov when stage > 1
- cache stage2 video and bump service worker cache version

## Testing
- `npx prettier --check app.js service-worker.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ebb33f8c832eafe54c6b9aad276c